### PR TITLE
Fix JSON Formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To run this application:
 ```json
 {
    "ConnectionStrings": {
-   "Forum": "<PostgreSQL Database Connection String>"
+      "Forum": "<PostgreSQL Database Connection String>"
    }
 }
 ```


### PR DESCRIPTION
- Corrected improper indention for the Forum item in the example JSON for the ConnectionStrings content in step #3 in the configuration instructions