### PR TITLE
Update to test/Data.Tests to Simplify Connecting to a Test Database

### DIFF
--- a/test/Data.Tests/Fixtures/DatabaseFixture.cs
+++ b/test/Data.Tests/Fixtures/DatabaseFixture.cs
@@ -1,23 +1,14 @@
 using System;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
-using System.Reflection.PortableExecutable;
-using Forum.Data;
-using Microsoft.Extensions.Configuration;
 
 namespace Data.Tests.Fixtures;
 
 public class DatabaseFixture : IDisposable
 {
-    public Database Database { get; }
+    public TestDatabase Database { get; }
     
     public DatabaseFixture()
     {
-        var config = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.Development.json")
-            .Build();
-        Database = new Database(config);
+        Database = new TestDatabase();
     }
     
     public void Dispose()

--- a/test/Data.Tests/Fixtures/TestDatabase.cs
+++ b/test/Data.Tests/Fixtures/TestDatabase.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Data;
+using Forum.Data.Interfaces;
+using Npgsql;
+
+namespace Data.Tests.Fixtures;
+
+public class TestDatabase : IDatabase
+{
+    private readonly string _connectionString;
+
+    public TestDatabase()
+    {
+        _connectionString = Environment.GetEnvironmentVariable("FORUM_TEST_DB") ??
+                            throw new InvalidOperationException("FORUM_TEST_DB environment variable is not set");
+    }
+
+    public IDbConnection Connect()
+    {
+        return new NpgsqlConnection(_connectionString);
+    }
+}


### PR DESCRIPTION
- Update to test/Data.Tests DatabaseFixture to use a new TestDatabase class that implements IDatabase.
- This allows for the standard configuration to be overridden and for the database connection string to be pulled from an environment variable instead of pulling from a appsettings.Development.json file.
- The main motivation for this is to simplify running unit tests via GitHub Actions.