### PR TITLE
Add Support for PUT Requests to api/topics/{id}

### DIFF
--- a/src/Forum.Api/Controllers/TopicsController.cs
+++ b/src/Forum.Api/Controllers/TopicsController.cs
@@ -20,7 +20,7 @@ public class TopicsController : ForumBaseController
     /// </summary>
     /// <returns>A collection containing data for all existing forum topics, if any exist.</returns>
     /// <response code="200">The requested topic was found.</response>
-    /// <response code="404">No topic was found matching the name passed into the URI path.</response>
+    /// <response code="204">No topics are currently defined.</response>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType((StatusCodes.Status204NoContent))]

--- a/src/Forum.Api/Controllers/TopicsController.cs
+++ b/src/Forum.Api/Controllers/TopicsController.cs
@@ -19,7 +19,7 @@ public class TopicsController : ForumBaseController
     /// Find and return a collection of all existing forum topics.
     /// </summary>
     /// <returns>A collection containing data for all existing forum topics, if any exist.</returns>
-    /// <response code="200">The requested topic was found.</response>
+    /// <response code="200">Topics are defined and were able to be located.</response>
     /// <response code="204">No topics are currently defined.</response>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]

--- a/src/Forum.Api/Controllers/TopicsController.cs
+++ b/src/Forum.Api/Controllers/TopicsController.cs
@@ -2,6 +2,7 @@ using Forum.Api.Controllers.Base;
 using Forum.Data.Abstractions;
 using Microsoft.AspNetCore.Mvc;
 using Forum.Data.Models;
+using Npgsql;
 
 namespace Forum.Api.Controllers;
 
@@ -17,12 +18,24 @@ public class TopicsController : ForumBaseController
     /// <summary>
     /// Find and return a collection of all existing forum topics.
     /// </summary>
-    /// <returns>A collection containing data for all existing forum topics.</returns>
+    /// <returns>A collection containing data for all existing forum topics, if any exist.</returns>
+    /// <response code="200">The requested topic was found.</response>
+    /// <response code="404">No topic was found matching the name passed into the URI path.</response>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public async Task<IEnumerable<Topic>> GetAllTopics()
+    [ProducesResponseType((StatusCodes.Status204NoContent))]
+    public async Task<IActionResult> GetAllTopics()
     {
-        return await _topics.GetAll();
+        var topics = await _topics.GetAll();
+        
+        if (topics.Any())
+        {
+            return Ok(topics);
+        }
+        else
+        {
+            return NoContent();
+        }
     }
     
     /// <summary>
@@ -30,6 +43,8 @@ public class TopicsController : ForumBaseController
     /// </summary>
     /// <param name="id">The unique ID for a single topic.</param>
     /// <returns>The data for the forum topic that was found using the provided ID.</returns>
+    /// <response code="200">The requested topic was found.</response>
+    /// <response code="404">No topic was found matching the ID passed into the URI path.</response>
     [HttpGet("{id:int}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -47,6 +62,8 @@ public class TopicsController : ForumBaseController
     /// </summary>
     /// <param name="name">The unique name for a single topic.</param>
     /// <returns>The data for the forum topic that was found using the provided name.</returns>
+    /// <response code="200">The requested topic was found.</response>
+    /// <response code="404">No topic was found matching the name passed into the URI path.</response>
     [HttpGet("{name}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -57,5 +74,48 @@ public class TopicsController : ForumBaseController
         if (topic is null) return NotFound();
 
         return topic;
+    }
+
+    /// <summary>
+    /// Update an existing forum topic matching the specified topic ID. 
+    /// </summary>
+    /// <param name="id">The unique ID for a single topic.</param>
+    /// <param name="topic">The topic values to replace the existing topic's values with.</param>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     PUT /api/topics/1
+    ///     {
+    ///        "id": 1,
+    ///        "name": "Weather",
+    ///        "Description": "Some weather we've been having, eh?"
+    ///     }
+    ///
+    /// </remarks>
+    /// <response code="204">The update was successful.</response>
+    /// <response code="400">The name is null, an empty string, or a different topic already has this name.</response>
+    /// <response code="404">No topic was found matching the ID passed into the URI path.</response>
+    [HttpPut("{id:int}")]
+    [Consumes("application/json")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateTopic(
+        [FromRoute] int id, 
+        [FromBody] Topic topic
+        )
+    {
+        var numberOfTopicsUpdated = 0;
+        
+        try
+        {
+            numberOfTopicsUpdated = await _topics.UpdateTopic(topic);
+        }
+        catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UniqueViolation)
+        {
+            return BadRequest("Name of topic is invalid");
+        }
+
+        return numberOfTopicsUpdated == 0 ? NotFound() : NoContent();
     }
 }

--- a/src/Forum.Data/Models/Topic.cs
+++ b/src/Forum.Data/Models/Topic.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Forum.Data.Models;
 
 /// <summary>
@@ -13,10 +15,13 @@ public class Topic
     /// <summary>
     /// The unique human-readable name of the topic.
     /// </summary>
+    ///         [Required]
+    [Required]
+    [MinLength(1)]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
     /// The optional detailed description of the topic.
     /// </summary>
-    public string Description { get; set; } = string.Empty;
+    public string? Description { get; set; }
 }

--- a/src/Forum.Data/Models/Topic.cs
+++ b/src/Forum.Data/Models/Topic.cs
@@ -15,7 +15,6 @@ public class Topic
     /// <summary>
     /// The unique human-readable name of the topic.
     /// </summary>
-    ///         [Required]
     [Required]
     [MinLength(1)]
     public string Name { get; set; } = string.Empty;

--- a/src/Forum.Data/Queries/Topics.cs
+++ b/src/Forum.Data/Queries/Topics.cs
@@ -86,6 +86,7 @@ public class Topics : ITopics
                 Id = topic.Id
             });
     }
+
     public async Task<int> RemoveAll()
     {
         using var connection = _database.Connect();


### PR DESCRIPTION
- Added support for PUT requests to the api/topics/{id} route in the Forum.Api project.
- Improved XML documentation for API controllers.
- Added data validation annotations to Topic model.
- Strengthened existing unit tests.