### PR TITLE
Add Swagger to Forum.Api/Fix Issues With PUT Requests to /api/topics/{id}

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ This application is a ASP.NET Core web application, with both an ASP.NET Core RE
 
 ## Installing Dependencies
 
-First, ensure that you have .NET 6 installed and configured on the target system. If not, please follow the instructions for your OS here: https://dotnet.microsoft.com/en-us/download/dotnet/6.0.
+First, ensure that you have .NET 6 installed and configured on the target system. If not, please follow the instructions for your OS here: [Download .NET 6](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).
 
 Then, navigate to the root of the application file system and run `dotnet restore` to install the NuGet dependencies for all projects within the solution.
 
-## Running the ASP.NET Core Web API Application
+## Forum.Api
 
-First, navigate to the /src/Forum.Api directory, and create a file named appsettings.Development.json.
+### Running the ASP.NET Core Web API Application
+
+First, navigate to the [/src/Forum.Api](https://github.com/ketchup-cfg/Forum-Web-App/tree/main/src/Forum.Api) directory, and create a file named appsettings.Development.json.
 
 Then, add the following content in the file to point the application to a configured PostgreSQL database:
 ```json
@@ -22,13 +24,23 @@ Then, add the following content in the file to point the application to a config
 }
 ```
 
-After the appsettings file has been configured, run `dotnet run` while in the /src/Forum.Api directory to run the ASP.NET Core Web API application.
+After the appsettings file has been configured, either run `dotnet run` from the [/src/Forum.Api](https://github.com/ketchup-cfg/Forum-Web-App/tree/main/src/Forum.Api) directory or run `dotnet run --project src/Forum.Api/Forum.Api.csproj` from the app's root directory to run the ASP.NET Core Web API application.
 
-## Running the ASP.NET Core Razor Pages Application (Work In Progress)
+### Swagger API Documentation
+
+This application provides functionality to serve documentation and a testing environment with Swagger at the `/swagger` endpoint when the application is run in a development environment.
+
+To ensure that you are running the application in a development environment, ensure that the `ASPNETCORE_ENVIRONMENT` environment variable is set to `"Development"`.
+
+Once this has been done, run `dotnet run --project src/Forum.Api/Forum.Api.csproj` to startup the Forum.Api application, the navigate to `https://localhost:<port>/swagger` in a web browser to view the Swagger documentation for the Forum.Api application.
+
+## Forum.Pages (Work In Progress)
+
+### Running the ASP.NET Core Razor Pages Application (Work In Progress)
 
 ***As a note, the work for the Razor Pages application has not progressed, yet, so as of right now, there is not much to see here.***
 
-First, navigate to the /src/Forum.Pages directory, and create a file named appsettings.Development.json.
+First, navigate to the [/src/Forum.Pages](https://github.com/ketchup-cfg/Forum-Web-App/tree/main/src/Forum.Pages) directory, and create a file named appsettings.Development.json.
 
 Then, add the following content in the file to point the application to a configured PostgreSQL database:
 ```json
@@ -39,15 +51,15 @@ Then, add the following content in the file to point the application to a config
 }
 ```
 
-After the appsettings file has been configured, run `dotnet run` while in the /src/Forum.Pages directory to run the ASP.NET Core Razor Pages application.
+After the appsettings file has been configured, run `dotnet run` while if still in the [/src/Forum.Pages](https://github.com/ketchup-cfg/Forum-Web-App/tree/main/src/Forum.Pages) directory to run the ASP.NET Core Razor Pages application. Or, you can just run `dotnet run --project src/Forum.Pages/Forum.Pages.csproj` from the app's root directory instead.
 
 ## Running Unit Tests
 
 To run unit tests for the application, first, ensure that you have a PostgreSQL database configured, and that you have the following environment variables set to whatever values you would prefer for your test PostgreSQL system:
-- POSTGRES_HOST
-- POSTGRES_PORT
-- POSTGRES_USER
-- POSTGRES_PASSWORD
-- POSTGRES_DB
+- `POSTGRES_HOST`
+- `POSTGRES_PORT`
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `POSTGRES_DB`
 
-Then, navigate to the root of the application file system and run `dotnet test` to run the unit tests for the application.
+Then, navigate to the root of the application file system and run `dotnet test` to run all unit tests for the application.

--- a/src/Forum.Api/Controllers/TopicsController.cs
+++ b/src/Forum.Api/Controllers/TopicsController.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Forum.Api.Controllers.Base;
 using Forum.Data.Abstractions;
 using Microsoft.AspNetCore.Mvc;
@@ -18,22 +19,21 @@ public class TopicsController : ForumBaseController
     /// <summary>
     /// Find and return a collection of all existing forum topics.
     /// </summary>
-    /// <returns>A collection containing data for all existing forum topics, if any exist.</returns>
+    /// <returns>A collection containing data for all existing forum topics.</returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     GET /api/topics
+    ///
+    /// </remarks>
+    /// <response code="200">Returns the collection of all existing forum topics.</response>
     [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    [ProducesResponseType((StatusCodes.Status204NoContent))]
     public async Task<IActionResult> GetAllTopics()
     {
         var topics = await _topics.GetAll();
-        
-        if (topics.Any())
-        {
-            return Ok(topics);
-        }
-        else
-        {
-            return NoContent();
-        }
+
+        return Ok(topics);
     }
     
     /// <summary>
@@ -41,16 +41,24 @@ public class TopicsController : ForumBaseController
     /// </summary>
     /// <param name="id">The unique ID for a single topic.</param>
     /// <returns>The data for the forum topic that was found using the provided ID.</returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     GET /api/topics/1
+    ///
+    /// </remarks>
+    /// <response code="200">Returns the found topic.</response>
+    /// <response code="404">No topic was found that matches the provided ID.</response>
     [HttpGet("{id:int}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<Topic>> GetTopicById([FromRoute] int id)
+    public async Task<IActionResult> GetTopicById([FromRoute] int id)
     {
         var topic = await _topics.GetTopicById(id);
 
         if (topic is null) return NotFound();
 
-        return topic;
+        return Ok(topic);
     }
     
     /// <summary>
@@ -58,6 +66,14 @@ public class TopicsController : ForumBaseController
     /// </summary>
     /// <param name="name">The unique name for a single topic.</param>
     /// <returns>The data for the forum topic that was found using the provided name.</returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     GET /api/topics/weather
+    ///
+    /// </remarks>
+    /// <response code="200">Returns the found topic.</response>
+    /// <response code="404">No topic was found that matches the provided name.</response>
     [HttpGet("{name}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -75,6 +91,23 @@ public class TopicsController : ForumBaseController
     /// </summary>
     /// <param name="topic">The new topic to be created.</param>
     /// <returns>The newly created topic, including its updated and current ID.</returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     POST /api/topics
+    ///     {
+    ///         "name": "weather",
+    ///         "description": "Let's talk about the weather."
+    ///     }
+    ///
+    /// </remarks>
+    /// <response code="201">
+    /// Returns the newly created topic, and the URI for this topic in the "location" header.
+    /// </response>
+    /// <response code="400">
+    /// There is an issue with the data that was sent for the new topic, please see the response body for more
+    /// information
+    /// </response>
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -95,8 +128,28 @@ public class TopicsController : ForumBaseController
     /// <summary>
     /// Update an existing forum topic matching the specified topic ID. 
     /// </summary>
-    /// <param name="id">The unique ID for a single topic.</param>
+    /// <param name="id">The unique ID for the topic to be updated.</param>
     /// <param name="topic">The topic values to replace the existing topic's values with.</param>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     PUT /api/topics/1
+    ///     {
+    ///         "id": 1,
+    ///         "name": "weathered",
+    ///         "description": "Let's talk about the weathered rocks."
+    ///     }
+    ///
+    /// </remarks>
+    /// <response code="204">
+    /// The topic was successfully updated with no issues.
+    /// </response>
+    /// <response code="400">
+    /// There is an issue with the data that was sent for the topic, please see the response body for more information.
+    /// </response>
+    /// <response code="404">
+    /// No topic was found that matches the ID passed into the URI route.
+    /// </response>
     [HttpPut("{id:int}")]
     [Consumes("application/json")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -108,19 +161,37 @@ public class TopicsController : ForumBaseController
         )
     {
         var numberOfTopicsUpdated = 0;
-        
+
         try
         {
-            numberOfTopicsUpdated = await _topics.UpdateTopic(topic);
+            numberOfTopicsUpdated = await _topics.UpdateTopic(id, topic);
         }
-        catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UniqueViolation)
+        catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UniqueViolation &&
+                                          e.ConstraintName == "topics_pkey")
         {
-            return BadRequest("Topic name is not unique and is already defined for another topic");
+            return BadRequest("New ID is not valid and is already defined for another topic and cannot be changed.");
+        }
+        catch (PostgresException e) when (e.SqlState == PostgresErrorCodes.UniqueViolation &&
+                                          e.ConstraintName == "topics_name_key")
+        {
+            return BadRequest("New name is not valid and is already defined for another topic and cannot be changed.");
         }
 
         return numberOfTopicsUpdated == 0 ? NotFound() : NoContent();
     }
 
+    /// <summary>
+    /// Delete the topic that matches the ID passed into the URI route.
+    /// </summary>
+    /// <param name="id">The unique ID for the topic to be deleted.</param>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     DELETE /api/topics/1
+    ///
+    /// </remarks>
+    /// <response code="204">The topic was successfully deleted with no issues.</response>
+    /// <response code="404">No topic was found that matches the ID passed into the URI route.</response>
     [HttpDelete("{id:int}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/Forum.Api/Forum.Api.csproj
+++ b/src/Forum.Api/Forum.Api.csproj
@@ -5,10 +5,16 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Forum.Data\Forum.Data.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Forum.Api/Program.cs
+++ b/src/Forum.Api/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Forum.Data;
 using Forum.Data.Abstractions;
 using Forum.Data.Queries;
@@ -13,14 +14,28 @@ builder.Services.AddCors(options =>
                 .AllowAnyMethod();
         });
 });
+
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
+
+builder.Services.AddSwaggerGen(options =>
+{
+    var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+});
+
 builder.Services.AddScoped<IDatabase, Database>();
 builder.Services.AddScoped<ITopics, Topics>();
 
 var app = builder.Build();
 
-//app.UseHttpsRedirection();
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
 app.UseAuthorization();
 app.UseCors();
 app.MapControllers();

--- a/src/Forum.Data/Abstractions/ITopics.cs
+++ b/src/Forum.Data/Abstractions/ITopics.cs
@@ -34,9 +34,10 @@ public interface ITopics
     /// <summary>
     /// Update the information for an existing topic.
     /// </summary>
+    /// <param name="id">The identifier for the topic to update.</param>
     /// <param name="topic">The values to use to replace the existing topic's data with.</param>
     /// <returns>The number of topics updated successfully.</returns>
-    public Task<int> UpdateTopic(Topic topic);
+    public Task<int> UpdateTopic(int id, Topic topic);
 
     /// <summary>
     /// Delete a topic definition that matches the provided ID.

--- a/src/Forum.Data/Queries/Topics.cs
+++ b/src/Forum.Data/Queries/Topics.cs
@@ -70,20 +70,22 @@ public class Topics : ITopics
             });
     }
 
-    public async Task<int> UpdateTopic(Topic topic)
+    public async Task<int> UpdateTopic(int id, Topic topic)
     {
         using var connection = _database.Connect();
         const string sql = @"update topics
-                                set name = @Name
-                                  , description = @Description
+                                set id = @NewId
+                                  , name = @NewName
+                                  , description = @NewDescription
                               where id = @Id;";
         
         return await connection.ExecuteAsync(sql, 
             new 
             {
-                Name = topic.Name,
-                Description = topic.Description,
-                Id = topic.Id
+                Id = id,
+                NewName = topic.Name,
+                NewDescription = topic.Description,
+                NewId = topic.Id
             });
     }
 

--- a/test/Forum.Data.Tests/Queries/TopicTests.cs
+++ b/test/Forum.Data.Tests/Queries/TopicTests.cs
@@ -184,7 +184,7 @@ public class TopicTests : IClassFixture<DatabaseFixture>
         mockTopic.Description = validDescription;
 
         // Act
-        var actual = await _topics.UpdateTopic(mockTopic);
+        var actual = await _topics.UpdateTopic(mockTopic.Id, mockTopic);
         
         // Assert
         Assert.Equal(expected, actual);
@@ -198,7 +198,7 @@ public class TopicTests : IClassFixture<DatabaseFixture>
         const string expected = PostgresErrorCodes.NotNullViolation;
         var mockTopic = await _helpers.CreateMockTopic();
         mockTopic.Name = invalidName;
-        Func<Task<int>> updateTopic = async () => await _topics.UpdateTopic(mockTopic);
+        Func<Task<int>> updateTopic = async () => await _topics.UpdateTopic(mockTopic.Id, mockTopic);
         
         // Act
         var actual = (await Record.ExceptionAsync(updateTopic) as PostgresException)!.SqlState;
@@ -215,7 +215,7 @@ public class TopicTests : IClassFixture<DatabaseFixture>
         var mockTopic1 = await _helpers.CreateMockTopic();
         var mockTopic2 = await _helpers.CreateMockTopic();
         mockTopic1.Name = mockTopic2.Name;
-        Func<Task<int>> updateTopic = async () => await _topics.UpdateTopic(mockTopic1);
+        Func<Task<int>> updateTopic = async () => await _topics.UpdateTopic(mockTopic1.Id, mockTopic1);
         
         // Act
         var actual = (await Record.ExceptionAsync(updateTopic) as PostgresException)!.SqlState;
@@ -232,7 +232,7 @@ public class TopicTests : IClassFixture<DatabaseFixture>
         var mockTopic = await _helpers.CreateMockTopic();
 
         // Act
-        var actual = await _topics.UpdateTopic(mockTopic);
+        var actual = await _topics.UpdateTopic(mockTopic.Id, mockTopic);
 
         // Assert
         Assert.Equal(expected, actual);


### PR DESCRIPTION
- Added support for Swagger API documentation to Forum.Api project.
- Added documentation improvements to README content, and updated README with new information for using Swagger.
- Updated Forum.Data.Queries.Topics.UpdateTopic to respect PUT requests better by allowing for the `id` column to be updated.
- Updated TopicsController to handle PUT requests for at /api/topics/{id} much better and return a more informational error message back to the caller to indicate which unique constraint was violated by the PUT request.